### PR TITLE
Change digdag-operator color brightblue

### DIFF
--- a/digdag-mode.el
+++ b/digdag-mode.el
@@ -37,7 +37,7 @@
   "Face of digdag operators")
 
 (defface digdag-operator
-  '((t (:foreground "red")))
+  '((t (:foreground "brightblue")))
   "Face of digdag operators")
 
 (defvar digdag-mode--date-regex


### PR DESCRIPTION
I think it's better to change `digdag-operator` color `red` to `brightblue` because Arm bought out Treasure Data and the theme color changed.